### PR TITLE
updated the docker-compose template

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ services:
   sf-processor:
     container_name: sf-processor
     image: sysflowtelemetry/sf-processor:latest
-    privileged: true
+    privileged: false
     volumes:
       - socket-vol:/sock/
     environment:
@@ -51,9 +51,9 @@ services:
       INPUT_PATH: /sock/sysflow.sock
       POLICYENGINE_MODE: alert
       EXPORTER_TYPE: telemetry
-      EXPORTER_SOURCE: ${HOSTNAME}
-      EXPORTER_EXPORT: terminal
-      EXPORTER_HOST: localhost
+      EXPORTER_SOURCE: sysflow
+      EXPORTER_EXPORT: syslog
+      EXPORTER_HOST: <IP address of the syslog server>
       EXPORTER_PORT: 514
   sf-collector:
     container_name: sf-collector
@@ -72,7 +72,7 @@ services:
       - socket-vol:/sock/
       - ./resources/traces:/tests/traces
     environment:
-      EXPORTER_ID: local
+      EXPORTER_ID: ${HOSTNAME}
       NODE_IP: "127.0.0.1"
       FILTER: "container.name!=sf-collector and container.name!=sf-processor" 
       INTERVAL: 300 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ services:
       - ./resources/traces:/tests/traces
     environment:
       EXPORTER_ID: ${HOSTNAME}
-      NODE_IP: "127.0.0.1"
+      NODE_IP: <Host IP address>
       FILTER: "container.name!=sf-collector and container.name!=sf-processor" 
       INTERVAL: 300 
       SOCK_FILE: /sock/sysflow.sock


### PR DESCRIPTION
1) updated the docker-compose file to use syslog as a default exporter

2) set the processor privileged flag to false

3) updated the env variable EXPORTER_SOURCE (the syslog identifier) to be a static value called sysflow, in this way, QRadar will have only one log source for sysflow, as the worker nodes might go up and down.