### PR TITLE
Stream driver fix for go 1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Changed policy engine modes and action verbs
 - Updated the short union strings from gogen-avro
 - Updated CI to automate packaging or release assets with release notes
-- Bump go version to go1.17.6
+- Bump go version to go1.17.7
+- BREAKING Added support for architecture-dependent build (darwin, linux), due to [changes in go 1.17 net](https://github.com/golang/go/commit/e97d8eb027c0067f757860b6f766644de15941f2) package
 
 ### Fixed
 
 - Fixed cache coherence and race condition when updating the cache in the processor plugin; splits the processor plugin into two plugins, reader (which builds the cache) and processor (only reads from cache)
+- Fixed stream socket reader issue introduced with the upgrade to go 1.17
 
 ## [0.3.1] - 2021-09-29
 

--- a/core/go.mod
+++ b/core/go.mod
@@ -19,7 +19,7 @@
 //
 module github.com/sysflow-telemetry/sf-processor/core
 
-go 1.14
+go 1.17
 
 require (
 	github.com/IBM/go-sdk-core/v3 v3.3.1
@@ -30,7 +30,6 @@ require (
 	github.com/elastic/go-elasticsearch/v8 v8.0.0-20210427093042-01613f93a7ae
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-openapi/strfmt v0.20.1
-	github.com/golang/snappy v0.0.3 // indirect
 	github.com/ibm-cloud-security/security-advisor-sdk-go/v3 v3.0.0
 	github.com/linkedin/goavro v2.1.0+incompatible
 	github.com/mailru/easyjson v0.7.6
@@ -38,10 +37,31 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/satta/gommunityid v0.0.0-20210315182841-1cdcb73ce408
 	github.com/steakknife/bloomfilter v0.0.0-20180922174646-6819c0d2a570
-	github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/sysflow-telemetry/sf-apis/go v0.0.0-20220204025248-25d44ab7fe1f
+)
+
+require (
+	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/go-openapi/errors v0.19.8 // indirect
+	github.com/go-playground/locales v0.13.0 // indirect
+	github.com/go-playground/universal-translator v0.17.0 // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/golang/snappy v0.0.3 // indirect
+	github.com/google/gopacket v1.1.19 // indirect
+	github.com/leodido/go-urn v1.2.0 // indirect
+	github.com/mitchellh/mapstructure v1.3.3 // indirect
+	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3 // indirect
+	go.mongodb.org/mongo-driver v1.5.1 // indirect
+	golang.org/x/net v0.0.0-20210825183410-e898025ed96a // indirect
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	gopkg.in/go-playground/validator.v9 v9.31.0 // indirect
 	gopkg.in/linkedin/goavro.v1 v1.0.5 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
 //replace github.com/sysflow-telemetry/sf-apis/go => ../../sf-apis/go

--- a/core/go.sum
+++ b/core/go.sum
@@ -384,7 +384,6 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
-github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -1097,7 +1096,6 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/driver/go.mod
+++ b/driver/go.mod
@@ -19,17 +19,57 @@
 //
 module github.com/sysflow-telemetry/sf-processor/driver
 
-go 1.14
+go 1.17
 
 require (
 	github.com/actgardner/gogen-avro/v7 v7.3.1
 	github.com/linkedin/goavro v2.1.0+incompatible
-	github.com/spf13/cast v1.3.1 // indirect
-	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.6.3
 	github.com/sysflow-telemetry/sf-apis/go v0.0.0-20220204025248-25d44ab7fe1f
 	github.com/sysflow-telemetry/sf-processor/core v0.0.0-20210709164444-484da05c2a85
+)
+
+require (
+	github.com/IBM/go-sdk-core/v3 v3.3.1 // indirect
+	github.com/RackSec/srslog v0.0.0-20180709174129-a4725f04ec91 // indirect
+	github.com/antlr/antlr4 v0.0.0-20200417160354-8c50731894e0 // indirect
+	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect
+	github.com/cespare/xxhash v1.1.0 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/elastic/go-elasticsearch/v8 v8.0.0-20210427093042-01613f93a7ae // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/go-openapi/errors v0.19.8 // indirect
+	github.com/go-openapi/strfmt v0.20.1 // indirect
+	github.com/go-playground/locales v0.13.0 // indirect
+	github.com/go-playground/universal-translator v0.17.0 // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/golang/snappy v0.0.3 // indirect
+	github.com/google/gopacket v1.1.19 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/ibm-cloud-security/security-advisor-sdk-go/v3 v3.0.0 // indirect
+	github.com/leodido/go-urn v1.2.0 // indirect
+	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/mitchellh/mapstructure v1.3.3 // indirect
+	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6 // indirect
+	github.com/pelletier/go-toml v1.8.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/satta/gommunityid v0.0.0-20210315182841-1cdcb73ce408 // indirect
+	github.com/spf13/afero v1.2.2 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/steakknife/bloomfilter v0.0.0-20180922174646-6819c0d2a570 // indirect
+	github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	go.mongodb.org/mongo-driver v1.5.1 // indirect
+	golang.org/x/net v0.0.0-20210825183410-e898025ed96a // indirect
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/text v0.3.6 // indirect
+	gopkg.in/go-playground/validator.v9 v9.31.0 // indirect
 	gopkg.in/ini.v1 v1.55.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
 replace github.com/sysflow-telemetry/sf-processor/core => ../core

--- a/driver/go.sum
+++ b/driver/go.sum
@@ -384,7 +384,6 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
-github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -1112,7 +1111,6 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/driver/sysflow/readmsgunixdarwin.go
+++ b/driver/sysflow/readmsgunixdarwin.go
@@ -1,0 +1,29 @@
+//
+// Copyright (C) 2020 IBM Corporation.
+//
+// Authors:
+// Frederico Araujo <frederico.araujo@ibm.com>
+// Teryl Taylor <terylt@ibm.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+
+// Package sysflow implements pluggable drivers for SysFlow ingestion.
+package sysflow
+
+// readMsgUnix reads a message from a unix socket (compatible with the Darwin architecture).
+func (s *StreamingDriver) readMsgUnix(buf []byte, oobuf []byte) error {
+	_, _, _, _, err := s.conn.ReadMsgUnix(buf[:], oobuf[:])
+	return err
+}

--- a/driver/sysflow/readmsgunixlinux.go
+++ b/driver/sysflow/readmsgunixlinux.go
@@ -27,7 +27,7 @@ import (
 	"syscall"
 )
 
-// readMsgUnix reads a message from a unix socket (compatible with the Darwin architecture).
+// readMsgUnix reads a message from a unix socket (compatible with the Linux architecture).
 func (s *StreamingDriver) readMsgUnix(buf []byte, oobuf []byte) error {
 	_, _, flags, _, err := s.conn.ReadMsgUnix(buf[:], oobuf[:])
 	if flags != syscall.MSG_CMSG_CLOEXEC {

--- a/driver/sysflow/readmsgunixlinux.go
+++ b/driver/sysflow/readmsgunixlinux.go
@@ -1,0 +1,37 @@
+//
+// Copyright (C) 2020 IBM Corporation.
+//
+// Authors:
+// Frederico Araujo <frederico.araujo@ibm.com>
+// Teryl Taylor <terylt@ibm.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+// Package sysflow implements pluggable drivers for SysFlow ingestion.
+package sysflow
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// readMsgUnix reads a message from a unix socket (compatible with the Darwin architecture).
+func (s *StreamingDriver) readMsgUnix(buf []byte, oobuf []byte) error {
+	_, _, flags, _, err := s.conn.ReadMsgUnix(buf[:], oobuf[:])
+	if flags != syscall.MSG_CMSG_CLOEXEC {
+		return fmt.Errorf("ReadMsgUnix flags = %v, want %v (MSG_CMSG_CLOEXEC)", flags, syscall.MSG_CMSG_CLOEXEC)
+	}
+	return err
+}


### PR DESCRIPTION
* Fixes stream socket reader issue introduced with the upgrade to go 1.17 
* Added support for architecture-dependent build (darwin, linux)
* Updated go compatibility level to 1.17

Signed-off-by: Frederico Araujo <frederico.araujo@ibm.com>