### PR TITLE
fix(policy engine): map int32 and bool fields correcly in MapStr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ install: build
 	cp ./resources/policies/distribution/* /usr/local/sysflow/resources/policies/
 
 .PHONY: docker-build
-docker-build:
+docker-build: docker-plugin-builder
 	( DOCKER_BUILDKIT=1 docker build --cache-from=sysflowtelemetry/plugin-builder:${SYSFLOW_VERSION} -t sysflowtelemetry/sf-processor:${SYSFLOW_VERSION} --build-arg UBI_VER=$(UBI_VERSION) --target=runtime -f Dockerfile . )
 
 .PHONY: docker-plugin-builder

--- a/core/policyengine/engine/fieldmapper.go
+++ b/core/policyengine/engine/fieldmapper.go
@@ -179,7 +179,14 @@ func (m FieldMapper) MapStr(attr string) StrFieldMap {
 			}
 			return trimBoundingQuotes(v)
 		} else if v, ok := o.(int64); ok {
+			if baseattr == SF_PROC_TTY || baseattr == SF_PROC_ENTRY {
+				return strconv.FormatBool(v != 0)
+			}
 			return strconv.FormatInt(v, 10)
+		} else if v, ok := o.(int32); ok { // sf.pproc.* int fields
+			return strconv.FormatInt(int64(v), 10)
+		} else if v, ok := o.(bool); ok { // sf.pproc.tty, sf.pproc.entry field
+			return strconv.FormatBool(v)
 		}
 
 		return sfgo.Zeros.String


### PR DESCRIPTION
Signed-off-by: Andreas Schade <san@zurich.ibm.com>

MapStr must also map int32 and boolean fields to strings. Without this fix references to fields of such types in a policy condition will always map to ""  leading to unexpected results.