### PR TITLE
fix(sysflow): fix double call to StartWorkers() function when policies are reloaded

### DIFF
--- a/core/policyengine/policyengine.go
+++ b/core/policyengine/policyengine.go
@@ -94,6 +94,9 @@ func (s *PolicyEngine) Init(conf map[string]interface{}) (err error) {
 			logger.Error.Printf("Unable to compile local policies from directory %s, %v", s.config.PoliciesPath, err)
 			return
 		}
+
+		// start workers
+		s.pi.StartWorkers()
 	} else {
 		s.policyMonitor, err = monitor.NewPolicyMonitor(s.config, s.createPolicyInterpreter, s.out)
 		if err != nil {
@@ -196,9 +199,6 @@ func (s *PolicyEngine) createPolicyInterpreter() (*engine.PolicyInterpreter[*com
 	if err != nil {
 		return nil, err
 	}
-
-	// start workers
-	pi.StartWorkers()
 
 	return pi, nil
 }


### PR DESCRIPTION
When a new policy file is loaded, sysflow rebuilds the policies using the function `createPolicyInterpreter`, that creates the policies and at the end calls the `pi.StartWorkers()`, that is in charge to start the worker processing the records and applying the rules.

The issue comes from the fact that the very same function `createPolicyInterpreter` is also used when a new modification to the policy files is detected in `CheckForPolicyUpdate`:

 - `createPolicyInterpreter` creates new policies and calls `pi.StartWorkers()`
 - `CheckForPolicyUpdate` sends a notification to p.interChan <- pi
 - the method `Process` in policyengine sees this notification and calls `s.pi.StopWorkers()` and `s.pi.StartWorkers()`

`StartWorkers` gets called twice, while `StopWorkers` is called once. This leads to concurrency issue, in particular `pi.workerCh` and `pi.wg` gets replaced twice in `StartWorkers` leading to inconsistencies in the wg counter.